### PR TITLE
makefile: ignore errors if policy isnt built yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ STANDARD_POLICY_SOURCES = policy/standard.cil \
 all: clean policy.$(POLICY_VERSION)
 
 clean:
-	$(RM) policy.$(POLICY_VERSION) file_contexts
+	$(RM) -f policy.$(POLICY_VERSION) file_contexts
 
 $(POLICY_VERSION): $(BASE_POLICY_SOURCES) $(STANDARD_POLICY_SOURCES)
 	$(SECILC) --policyvers=$(POLICY_VERSION) --o="$@" $^


### PR DESCRIPTION
Prevents make failing if invoked with the default target as `make` when
policy.$version or file_contexts files do not exist yet.

```
gtierney@home-pc dssp2-standard
> $ make
/bin/rm policy.30 file_contexts
/bin/rm: cannot remove 'policy.30': No such file or directory
/bin/rm: cannot remove 'file_contexts': No such file or directory
Makefile:74: recipe for target 'clean' failed
make: *** [clean] Error 1
```